### PR TITLE
ensure comment nodes always have ranges

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,5 +11,10 @@ exports.convertComments = function (comments) {
     } else if (comment.type === "CommentLine") {
       comment.type = "Line";
     }
+    // sometimes comments don't get ranges computed,
+    // even with options.ranges === true
+    if (!comment.range) {
+      comment.range = [comment.start, comment.end];
+    }
   }
 }


### PR DESCRIPTION
This appears to be the root cause of the [Travis failure](https://travis-ci.org/babel/babel-eslint/jobs/90325188) in babel/babel-eslint/pull/202

Regressed by `npm link` into the babel6 branch of babel-eslint (with my latest fix applied, babel/babel-eslint/pull/212), since this module has no tests of its own.